### PR TITLE
Return newsletter strings for DB save

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,16 +122,16 @@ def run_newsletter_generation():
             'generated_at': datetime.now().isoformat()
         }
         
-        success = build_newsletter(newsletter_data, config)
-        
+        success, html_content, markdown_content, text_content = build_newsletter(newsletter_data, config)
+
         if success:
             # Save newsletter and articles to database
             newsletter_data_db = {
                 'title': f"Planner Pulse - {datetime.now().strftime('%Y-%m-%d')}",
                 'subject_line': subject_line,
-                'html_content': '',  # Build_newsletter creates files, not content dict
-                'markdown_content': '',
-                'text_content': '',
+                'html_content': html_content,
+                'markdown_content': markdown_content,
+                'text_content': text_content,
                 'sponsor': current_sponsor
             }
             

--- a/test_app.py
+++ b/test_app.py
@@ -121,8 +121,8 @@ def generate_newsletter():
             'generated_at': datetime.now().isoformat()
         }
         
-        success = build_newsletter(newsletter_data, config)
-        
+        success, _, _, _ = build_newsletter(newsletter_data, config)
+
         if success:
             flash('Test newsletter generated successfully!', 'success')
             logger.info("Test newsletter generation completed successfully")


### PR DESCRIPTION
## Summary
- have builder return HTML/Markdown/text strings
- include those strings when saving newsletter to the database
- adjust test app for new return signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d8be4dd8832a9fac92844f299f72